### PR TITLE
Update Ungoogled to 79.0.3945.117

### DIFF
--- a/Casks/marmaduke-chromium-ungoogled.rb
+++ b/Casks/marmaduke-chromium-ungoogled.rb
@@ -1,6 +1,6 @@
 cask 'marmaduke-chromium-ungoogled' do
-  version '79.0.3945.79'
-  sha256 '6157da29da105c6b4b32fd909e71f7c6f524c972d17dd7e53b2ba775e6d831a8'
+  version '79.0.3945.117'
+  sha256 '330cf70e7b5731229c66293bcb761173beea7f455aa783659f36b51d8da32586'
 
   url "https://github.com/macchrome/macstable/releases/download/v#{version}-r706915-Ungoogled-macOS/Chromium.app.ungoogled-#{version}.zip"
   appcast 'https://github.com/macchrome/macstable/releases.atom'

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 All Chromium releases can be found at [Woolyss](https://chromium.woolyss.com).
 Builds are pulled from [macchrome/macstable](https://github.com/macchrome/macstable).
 
-**Current Version:** 79.0.3945.79 (706915)
+**Current Version:** 79.0.3945.79 (706915) / Ungoogled 79.0.3945.117 (706915)
 
 ![](https://github.com/mtslzr/marmaduke-chromium/workflows/Test/badge.svg)
 


### PR DESCRIPTION
https://github.com/macchrome/macstable/releases/tag/v79.0.3945.117-r706915-Ungoogled-macOS