### PR TITLE
Update Ungoogled to 84.0.4147.89

### DIFF
--- a/Casks/marmaduke-chromium-ungoogled.rb
+++ b/Casks/marmaduke-chromium-ungoogled.rb
@@ -1,8 +1,8 @@
 cask 'marmaduke-chromium-ungoogled' do
-  version '83.0.4103.116'
-  sha256 'e7d6be4fe5dfe989adf65f92d0d64a1f93efb41693a7b89a6602a3d31f431979'
+  version '84.0.4147.89'
+  sha256 'f2117dc79c51b997f57464b53593e6bbfa914bd9f3e2eb58891f33016c578e7c'
 
-  url "https://github.com/macchrome/macstable/releases/download/v#{version}-r756066-Ungoogled-macOS/Chromium.app.ungoogled-#{version}.zip"
+  url "https://github.com/macchrome/macstable/releases/download/v#{version}-r768962-Ungoogled-macOS/Chromium.app.ungoogled-#{version}.zip"
   appcast 'https://github.com/macchrome/macstable/releases.atom'
   name 'Chromium'
   homepage 'https://github.com/macchrome/macstable/releases'

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Builds are pulled from [macchrome/macstable](https://github.com/macchrome/macsta
 
 ![](https://img.shields.io/badge/marmaduke--chromium--nosync-84.0.4147.89%20(768962)-lightblue)
 
-![](https://img.shields.io/badge/marmaduke--chromium--ungoogled-83.0.4103.116%20(756066)-yellow)
+![](https://img.shields.io/badge/marmaduke--chromium--ungoogled-84.0.4147.89%20(768962)-yellow)
 
 ## Installation
 


### PR DESCRIPTION
https://github.com/macchrome/macstable/releases/tag/v84.0.4147.89-r768962-Ungoogled-macOS