### PR TITLE
gh-action: update regex for name of sync.app in sync.py

### DIFF
--- a/.github/workflows/sync.py
+++ b/.github/workflows/sync.py
@@ -47,7 +47,7 @@ end
 """},
 
     "sync.app": {
-        "name": r"Chromium\.(\d+\.){3}\d+\.sync\.app\.(zip|tar\.xz)",
+        "name": r"Chromium\.app\.sync-(\d+\.){3}\d+\.(zip|tar\.xz)",
         "pattern": r"marmaduke--chromium-(\d+\.){3}\d+%20\(\d+\)-blue",
         "replace": "marmaduke--chromium-{version}%20({revision})-blue",
         "path": "marmaduke-chromium.rb",

--- a/Casks/marmaduke-chromium.rb
+++ b/Casks/marmaduke-chromium.rb
@@ -1,8 +1,8 @@
 cask 'marmaduke-chromium' do
-  version '100.0.4896.60'
-  sha256 '009a12762dacc08fe185c03f238c78672a1fba525ce4c6c04b90f9ef7db154ec'
+  version '109.5414.65'
+  sha256 '9ca67d6a19f96d57462bcd76470771ad16ba7aee410de3f61bd90ddb217eaec8'
 
-  url 'https://github.com/macchrome/macstable/releases/download/v100.0.4896.60-r972766-macOS/Chromium.100.0.4896.60.sync.app.zip'
+  url 'https://github.com/macchrome/macstable/releases/download/v109.5414.65-M109.0.5414.65-r1070088-macOS/Chromium.app.sync-109.0.5414.65.zip'
   appcast 'https://github.com/macchrome/macstable/releases.atom'
   name 'Chromium'
   homepage 'https://github.com/macchrome/macstable/releases'

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Builds are pulled from [macchrome/macstable](https://github.com/macchrome/macsta
 
 **Current Versions**
 
-![](https://img.shields.io/badge/marmaduke--chromium-100.0.4896.60%20(972766)-blue)
+![](https://img.shields.io/badge/marmaduke--chromium-109.5414.65%20(1070088)-blue)
 
 ![](https://img.shields.io/badge/marmaduke--chromium--nosync-84.0.4147.89%20(768962)-lightblue)
 


### PR DESCRIPTION
Hi, I noticed that the auto-sync for sync.app has been broken since macstable changed its naming convention, and this PR updates the regex for that.